### PR TITLE
Remove dead bugged profile code

### DIFF
--- a/inc/profile.class.php
+++ b/inc/profile.class.php
@@ -218,20 +218,6 @@ class PluginKarastockProfile extends Profile {
     public static function initProfile() {
         global $DB;
 
-        $profile = new self();
-  
-        //Add new rights in glpi_profilerights table
-        foreach ($profile->getAllRights() as $data) {
-
-            if (countElementsInTable(
-                "glpi_profilerights",
-                "`name` = '" . $data['field'] . "'"
-            ) == 0) {
-
-                //ProfileRight::addProfileRights([$data['field']]);
-            }
-        }
-
         $profiles = $DB->request("SELECT *
             FROM `glpi_profilerights`
             WHERE `profiles_id`='" . $_SESSION['glpiactiveprofile']['id'] . "'


### PR DESCRIPTION
There is a for loop with a condition with nothing inside it except a comment. The code should probably just be removed.
The main issue though is the call to `countElementsInTable` is incorrect. The second parameter must be an array. This array uses the same format as the DB iterator.

Example:
`['name' => $data['field']]`

This bug is preventing the plugin from being installed.