### PR TITLE
Fix invalid table charset

### DIFF
--- a/inc/order.class.php
+++ b/inc/order.class.php
@@ -88,7 +88,7 @@ class PluginKarastockOrder extends CommonDBTM {
                 PRIMARY KEY  (`id`),
                 KEY `status` (`status`),
                 KEY `name` (`name`)
-            ) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8mb4_unicode_ci";
+            ) ENGINE=InnoDB  DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci";
 
             $DB->query($query) or die("error creating $table " . $DB->error());
             

--- a/inc/orderitem.class.php
+++ b/inc/orderitem.class.php
@@ -89,7 +89,7 @@ class PluginKarastockOrderItem extends CommonDBChild {
                 `comment` varchar(255) collate utf8mb4_unicode_ci default NULL, 
 
                 PRIMARY KEY  (`id`)
-            ) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8mb4_unicode_ci";
+            ) ENGINE=InnoDB  DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci";
 
             $DB->query($query) or die("error creating $table " . $DB->error());
         }        


### PR DESCRIPTION
For `utf8mb4_unicode_ci` collation to be used, the charset must be `utf8mb4`.